### PR TITLE
Bug fixes

### DIFF
--- a/Il2CppInspector.Common/FileFormatStreams/PEReader.cs
+++ b/Il2CppInspector.Common/FileFormatStreams/PEReader.cs
@@ -182,7 +182,7 @@ namespace Il2CppInspector
             var exportAddresses = ReadArray<uint>(MapVATR(exportDirectoryTable.AddressOfFunctions + pe.ImageBase), exportCount);
             var exports = exportAddresses.Select((a, i) => new Export {
                 Ordinal = (int) (exportDirectoryTable.Base + i),
-                VirtualAddress = GlobalOffset + a
+                VirtualAddress = pe.ImageBase + a
             }).ToDictionary(x => x.Ordinal, x => x);
 
             // Get export names

--- a/Il2CppInspector.Common/Reflection/ParameterInfo.cs
+++ b/Il2CppInspector.Common/Reflection/ParameterInfo.cs
@@ -131,7 +131,7 @@ namespace Il2CppInspector.Reflection
               $"{CustomAttributes.ToString(usingScope, inline: true, emitPointer: emitPointer, mustCompile: compileAttributes).Replace("[ParamArray]", "params")}"
             + (Position == 0 && DeclaringMethod.GetCustomAttributes("System.Runtime.CompilerServices.ExtensionAttribute").Any()? "this ":"")
             + $"{getCSharpSignatureString(usingScope)} {CSharpName}"
-            + (IsOptional? " = " + DefaultValue.ToCSharpValue(ParameterType, usingScope) 
+            + ((DefaultValue is not null && IsOptional)? " = " + DefaultValue.ToCSharpValue(ParameterType, usingScope) 
             + (emitPointer && !(DefaultValue is null)? $" /* Metadata: 0x{(uint) DefaultValueMetadataAddress:X8} */" : "") : "");
 
         public string GetReturnParameterString(Scope scope) => !IsRetval? null : getCSharpSignatureString(scope);


### PR DESCRIPTION
Hi,

when trying to use Il2CppInspector on slightly obfuscated game builds, 
the code generator crashes when parameter default values are missing.
Additionally, parsing of the PE export table results in incorrect addresses.

In this pull request I propose fixes for both issues and I kindly ask to merge those.

Thank you.